### PR TITLE
fix: update jest to ^30.2.0 to fix installation failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "glob": "^11.0.3",
     "husky": "^9.1.7",
     "ignore": "^7.0.5",
-    "jest": "^30.0.4",
+    "jest": "^30.2.0",
     "js-yaml": "^4.1.0",
     "lint-staged": "^16.1.1",
     "markdownlint-cli2": "^0.19.1",


### PR DESCRIPTION
## Summary
- Updates jest dependency from `^30.0.4` to `^30.2.0`
- Jest 30.0.4 was not available on npm registry during installation, causing `No matching version found for jest@^30.0.4` error

## Related Issue
Fixes bmad-code-org/BMAD-METHOD#1411

## Test plan
- [ ] Run `npx bmad-method install` and select BMM module
- [ ] Verify dependencies install successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated testing dependencies for improved development tooling.

---

**Note:** This release contains only internal maintenance updates with no changes to user-facing functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->