### PR TITLE
fix: correct workflow and step entry point filenames

### DIFF
--- a/src/workflows/agent/steps-e/e-01-load-existing.md
+++ b/src/workflows/agent/steps-e/e-01-load-existing.md
@@ -4,7 +4,7 @@ description: 'Load and analyze existing agent for editing'
 
 # File References
 thisStepFile: ./e-01-load-existing.md
-workflowFile: ../workflow.md
+workflowFile: ../workflow-edit-agent.md
 nextStepFile: './e-02-discover-edits.md'
 editPlan: '{bmb_creations_output_folder}/edit-plan-{agent-name}.md'
 agentMetadata: ../data/agent-metadata.md

--- a/src/workflows/module/steps-c/step-01b-continue.md
+++ b/src/workflows/module/steps-c/step-01b-continue.md
@@ -2,7 +2,7 @@
 name: 'step-01b-continue'
 description: 'Handle workflow continuation for Create mode'
 
-workflowFile: '../workflow.md'
+workflowFile: '../workflow-create-module.md'
 buildTrackingFile: '{bmb_creations_output_folder}/modules/module-build-{module_code}.md'
 ---
 

--- a/src/workflows/module/workflow-edit-module.md
+++ b/src/workflows/module/workflow-edit-module.md
@@ -3,7 +3,7 @@ name: edit-module
 description: Edit existing BMAD modules while maintaining coherence
 web_bundle: true
 installed_path: '{project-root}/_bmad/bmb/workflows/module'
-editWorkflow: './steps-e/step-01-assess.md'
+editWorkflow: './steps-e/step-01-load-target.md'
 ---
 
 # Edit Module


### PR DESCRIPTION
## Summary

- Fix 3 broken file references where workflow entry points use wrong filenames
- Agent edit: `../workflow.md` → `../workflow-edit-agent.md`
- Module create continue: `../workflow.md` → `../workflow-create-module.md`
- Module edit workflow: `step-01-assess.md` → `step-01-load-target.md`

## Found by

File reference validator ([PR #8](https://github.com/bmad-code-org/bmad-builder/pull/8))

Fixes #17, #18, #19

## Files changed

| File | Fix |
|------|-----|
| `agent/steps-e/e-01-load-existing.md` | `workflow.md` → `workflow-edit-agent.md` |
| `module/steps-c/step-01b-continue.md` | `workflow.md` → `workflow-create-module.md` |
| `module/workflow-edit-module.md` | `step-01-assess.md` → `step-01-load-target.md` |

## Why is this safe

These are frontmatter path corrections only. Each fix points the reference to the workflow or step file that actually exists and serves as the correct entry point for its respective flow.