### PR TITLE
Replace bmad-init dependency with direct config loading

### DIFF
--- a/src/skills/bmad-agent-builder/SKILL.md
+++ b/src/skills/bmad-agent-builder/SKILL.md
@@ -26,7 +26,12 @@ These agents become part of the BMad Method ecosystem — personal companions th
 
 ## On Activation
 
-1. Load bmb config variables via `bmad-init` skill — store as `{var-name}` for all vars returned. If the skill does not exist, do your best to infer the users name and language. Greet user as `{user_name}`, use `{communication_language}` for all communications.
+1. Load config from `{project-root}/_bmad/bmb/config.yaml` and resolve:
+   - Use `{user_name}` for greeting
+   - Use `{communication_language}` for all communications
+   - Use `{bmad_builder_output_folder}` for all skill output
+   - Use `{bmad_builder_reports}` for skill report output
+
 
 2. Detect user's intent from their request:
 

--- a/src/skills/bmad-workflow-builder/SKILL.md
+++ b/src/skills/bmad-workflow-builder/SKILL.md
@@ -26,7 +26,11 @@ These workflows become part of the BMad Method ecosystem. If the user with your 
 
 ## On Activation
 
-1. Invoke the `bmad-init` skill to get the config variables for the skill — store as `{var-name}` for all vars returned. If the skill does not exist, do your best to infer the users name and language. Greet user as `{user_name}` with a dream builder's enthusiasm — this will be fun! Always use `{communication_language}` for all communications.
+1. Load config from `{project-root}/_bmad/bmb/config.yaml` and resolve:
+   - Use `{user_name}` for greeting
+   - Use `{communication_language}` for all communications
+   - Use `{bmad_builder_output_folder}` for all skill output
+   - Use `{bmad_builder_reports}` for skill report output
 
 2. Detect user's intent from their request:
 


### PR DESCRIPTION
## Summary
- Agent-builder and workflow-builder skills now load config directly from `{project-root}/_bmad/bmb/config.yaml` instead of invoking the `bmad-init` skill
- Makes both skills self-contained — no external skill dependency needed for initialization
- Explicitly lists resolved config variables (`user_name`, `communication_language`, `bmad_builder_output_folder`, `bmad_builder_reports`)

## Test plan
- [ ] Run agent-builder skill and verify it loads config correctly
- [ ] Run workflow-builder skill and verify it loads config correctly
- [ ] Verify greeting uses `{user_name}` from config
- [ ] Verify output goes to `{bmad_builder_output_folder}`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Agent Builder and Workflow Builder skill configuration to load settings from YAML file instead of dynamic skill initialization. Settings now explicitly define user name, communication language, and output folder paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->