### PR TITLE
feat: add module-help.csv and module.yaml to src/skills

### DIFF
--- a/src/skills/module-help.csv
+++ b/src/skills/module-help.csv
@@ -1,0 +1,6 @@
+module,skill,display-name,menu-code,description,action,args,phase,after,before,required,output-location,outputs
+BMad Builder,bmad-builder-setup,Setup Builder Module,SB,"Install or update BMad Builder module config and help entries. Collects user preferences, writes config.yaml, and migrates legacy configs.",configure,,anytime,,,false,{project-root}/_bmad,config.yaml and config.user.yaml
+BMad Builder,bmad-agent-builder,Build an Agent,BA,"Create, edit, convert, or fix an agent skill.",build-process,"[-H] [description | path]",anytime,,bmad-agent-builder:quality-optimizer,false,output_folder,agent skill
+BMad Builder,bmad-agent-builder,Optimize an Agent,OA,Validate and optimize an existing agent skill. Produces a quality report.,quality-optimizer,[-H] [path],anytime,bmad-agent-builder:build-process,,false,bmad_builder_reports,quality report
+BMad Builder,bmad-workflow-builder,Build a Workflow,BW,"Create, edit, convert, or fix a workflow or utility skill.",build-process,"[-H] [description | path]",anytime,,bmad-workflow-builder:quality-optimizer,false,output_folder,workflow skill
+BMad Builder,bmad-workflow-builder,Optimize a Workflow,OW,Validate and optimize an existing workflow or utility skill. Produces a quality report.,quality-optimizer,[-H] [path],anytime,bmad-workflow-builder:build-process,,false,bmad_builder_reports,quality report

--- a/src/skills/module.yaml
+++ b/src/skills/module.yaml
@@ -1,0 +1,20 @@
+code: bmb
+name: "BMad Builder"
+description: "Standard Skill Compliant Factory for BMad Agents, Workflows and Modules"
+module_version: 1.0.0
+default_selected: false
+module_greeting: >
+  Enjoy making your dream creations with the BMad Builder Module!
+  Run this again at any time if you want to reconfigure a setting or have updated the module, (or optionally just update _bmad/config.yaml and config.user.yaml to change existing values)
+
+  For questions, suggestions and support - check us on Discord at https://discord.gg/gk8jAdXWmj
+
+bmad_builder_output_folder:
+  prompt: "Where should your custom output (agent, workflow, module config) be saved?"
+  default: "{project-root}/skills"
+  result: "{project-root}/{value}"
+
+bmad_builder_reports:
+  prompt: "Output for Evals, Test, Quality and Planning Reports?"
+  default: "{project-root}/skills/reports"
+  result: "{project-root}/{value}"


### PR DESCRIPTION
## Summary
- Add `src/skills/module-help.csv` — canonical module help catalog at the skills level (new 13-column format)
- Add `src/skills/module.yaml` — module configuration prompts and defaults

These were part of the module-builder branch work but missed the CSV format PR (#37).

## Test plan
- [ ] Verify setup skill reads module.yaml correctly
- [ ] Verify module-help.csv at src/skills/ is picked up by installer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added BMad Builder skill module for enhanced output generation and management.
  * Introduced configurable settings to specify custom locations for generated files and project reports.
  * Includes sensible default paths that can be easily customized to match your project structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->