### PR TITLE
fix: HTML quality report renders empty due to data injection mismatch

### DIFF
--- a/skills/bmad-agent-builder/scripts/generate-html-report.py
+++ b/skills/bmad-agent-builder/scripts/generate-html-report.py
@@ -491,7 +491,7 @@ init();
 def generate_html(report_data: dict) -> str:
     data_json = json.dumps(report_data, indent=None, ensure_ascii=False)
     data_tag = f'<script id="report-data" type="application/json">{data_json}</script>'
-    html = HTML_TEMPLATE.replace('<script>\nconst DATA', f'{data_tag}\n<script>\nconst DATA')
+    html = HTML_TEMPLATE.replace('<script>\nconst RAW', f'{data_tag}\n<script>\nconst RAW')
     html = html.replace('SKILL_NAME', report_data.get('meta', {}).get('skill_name', 'Unknown'))
     return html
 

--- a/skills/bmad-workflow-builder/scripts/generate-html-report.py
+++ b/skills/bmad-workflow-builder/scripts/generate-html-report.py
@@ -477,7 +477,7 @@ def generate_html(report_data: dict) -> str:
     """Inject report data into the HTML template."""
     data_json = json.dumps(report_data, indent=None, ensure_ascii=False)
     data_tag = f'<script id="report-data" type="application/json">{data_json}</script>'
-    html = HTML_TEMPLATE.replace('<script>\nconst DATA', f'{data_tag}\n<script>\nconst DATA')
+    html = HTML_TEMPLATE.replace('<script>\nconst RAW', f'{data_tag}\n<script>\nconst RAW')
     html = html.replace('SKILL_NAME', report_data.get('meta', {}).get('skill_name', 'Unknown'))
     return html
 


### PR DESCRIPTION
The template was refactored to use `const RAW = JSON.parse(...)` with a normalize step, but the Python generate_html() still looked for `const DATA` — the replace never matched, so the JSON data tag was never injected into the HTML.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed HTML report generation to correctly embed and parse report data, ensuring proper alignment between the injected JSON content and the corresponding parser script in the generated templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->