### PR TITLE
docs: remove bmad-init references from workflow-patterns

### DIFF
--- a/docs/reference/workflow-patterns.md
+++ b/docs/reference/workflow-patterns.md
@@ -9,8 +9,8 @@ Reference for how the BMad Builder classifies and structures skills. Every skill
 
 | Type | Description | Structure |
 | ---- | ----------- | --------- |
-| **Simple Utility** | Input/output building block. Headless, composable, often script-driven. May opt out of `bmad-init` for true standalone use | SKILL.md + `scripts/` |
-| **Simple Workflow** | Multi-step process contained in a single SKILL.md. Uses `bmad-init`. Minimal or no `prompts/` | SKILL.md + optional `resources/` |
+| **Simple Utility** | Input/output building block. Headless, composable, often script-driven. May opt out of config loading for true standalone use | SKILL.md + `scripts/` |
+| **Simple Workflow** | Multi-step process contained in a single SKILL.md. Loads config directly from module config.yaml. Minimal or no `prompts/` | SKILL.md + optional `resources/` |
 | **Complex Workflow** | Multi-stage with progressive disclosure, stage prompts in `prompts/`, config integration. May support headless mode | SKILL.md (routing) + `prompts/` stages + `resources/` |
 
 ## Decision Tree
@@ -109,6 +109,6 @@ Module membership is orthogonal to skill type — any type can be standalone or 
 
 | Context | Naming | Init |
 | ------- | ------ | ---- |
-| **Module-based** | `bmad-{modulecode}-{skillname}` | Uses `bmad-init` with module code |
-| **Standalone** | `bmad-{skillname}` | Uses `bmad-init` by default; simple utilities may opt out |
+| **Module-based** | `bmad-{modulecode}-{skillname}` | Loads config from module config.yaml |
+| **Standalone** | `bmad-{skillname}` | Loads config from module config.yaml; simple utilities may opt out |
 


### PR DESCRIPTION
## Summary

- Update workflow-patterns.md to replace bmad-init references with direct config.yaml loading
- Reflects removal of bmad-init skill from core framework (bmad-code-org/BMAD-METHOD#2159)

## Test plan

- [ ] Verify docs render correctly