### PR TITLE
Fix invalid YAML frontmatter in setup skill template

### DIFF
--- a/skills/bmad-module-builder/assets/setup-skill-template/SKILL.md
+++ b/skills/bmad-module-builder/assets/setup-skill-template/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: { setup-skill-name }
+name: "{setup-skill-name}"
 description: Sets up {module-name} module in a project. Use when the user requests to 'install {module-code} module', 'configure {module-name}', or 'setup {module-name}'.
 ---
 

--- a/skills/bmad-module-builder/scripts/tests/test-scaffold-setup-skill.py
+++ b/skills/bmad-module-builder/scripts/tests/test-scaffold-setup-skill.py
@@ -95,6 +95,12 @@ def test_skill_md_frontmatter_substitution():
         assert "{module-code}" not in skill_md
 
 
+def test_template_frontmatter_uses_quoted_name_placeholder():
+    """Test that the template frontmatter is valid before substitution."""
+    template_skill_md = (TEMPLATE_DIR / "SKILL.md").read_text()
+    assert 'name: "{setup-skill-name}"' in template_skill_md
+
+
 def test_generated_files_written():
     """Test that module.yaml and module-help.csv contain generated content."""
     with tempfile.TemporaryDirectory() as tmp:
@@ -201,6 +207,7 @@ if __name__ == "__main__":
     tests = [
         test_basic_scaffold,
         test_skill_md_frontmatter_substitution,
+        test_template_frontmatter_uses_quoted_name_placeholder,
         test_generated_files_written,
         test_anti_zombie_replaces_existing,
         test_missing_target_dir,


### PR DESCRIPTION
Summary:
- quote the name placeholder in the setup skill template frontmatter
- add a regression test to keep the template valid before substitution

Why:
Codex scans every SKILL.md under installed skills. The unquoted placeholder name: { setup-skill-name } is parsed as a YAML map instead of a string, so the template file is skipped as an invalid skill during startup.

Validation:
- python3 skills/bmad-module-builder/scripts/tests/test-scaffold-setup-skill.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Skill template metadata formatting now uses quoted placeholder values for more consistent and robust template files, reducing ambiguity in generated content.

* **Tests**
  * Added validation to ensure skill template front-matter uses the quoted placeholder format, and included this check in the scaffold test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->