### PR TITLE
Add sample plugins to marketplace.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -22,6 +22,35 @@
         "./skills/bmad-module-builder",
         "./skills/bmad-workflow-builder"
       ]
+    },
+    {
+      "name": "sample-plugins",
+      "source": "./samples",
+      "description": "Sample plugins demonstrating how to build BMad agents and skills. Includes a code coach, creative muse, diagram reviewer, dream weaver, sentinel, and excalidraw generator.",
+      "version": "1.0.0",
+      "author": {
+        "name": "Brian (BMad) Madison"
+      },
+      "skills": [
+        "./samples/bmad-agent-code-coach",
+        "./samples/bmad-agent-creative-muse",
+        "./samples/bmad-agent-diagram-reviewer",
+        "./samples/bmad-agent-dream-weaver",
+        "./samples/bmad-agent-sentinel",
+        "./samples/bmad-excalidraw"
+      ]
+    },
+    {
+      "name": "bmad-dream-weaver-agent",
+      "source": "./samples/bmad-agent-dream-weaver",
+      "description": "Dream journaling and interpretation agent with lucid dreaming coaching, pattern discovery, symbol analysis, and recall training.",
+      "version": "1.0.0",
+      "author": {
+        "name": "Brian (BMad) Madison"
+      },
+      "skills": [
+        "./samples/bmad-agent-dream-weaver"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add `sample-plugins` plugin entry with all 6 sample skills
- Add standalone `bmad-dream-weaver-agent` plugin entry
- For installer testing purposes

## Test plan
- [ ] Verify installer does not surface these plugins (marketplace.json is not read by installer)
- [ ] Use as target repo for bmad installer integration tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Two new plugin collections are now available in the marketplace. The sample plugins collection provides six tools: Code Coach for development assistance, Creative Muse for creative tasks, Diagram Reviewer for visualization analysis, Dream Weaver for ideation, Sentinel for monitoring, and Excalidraw for diagram creation. The specialized Dream Weaver Agent plugin has also been added.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->