### PR TITLE
Fix BMB skills to fall back to legacy per-module config

### DIFF
--- a/skills/bmad-agent-builder/SKILL.md
+++ b/skills/bmad-agent-builder/SKILL.md
@@ -19,7 +19,7 @@ Act as an architect guide — walk users through conversational discovery to und
 
 1. Detect user's intent. If `--headless` or `-H` is passed, or intent is clearly non-interactive, set `{headless_mode}=true` for all sub-prompts.
 
-2. Load available config from `{project-root}/_bmad/config.yaml` and `{project-root}/_bmad/config.user.yaml` (root and bmb section). If missing, and the `bmad-builder-setup` skill is available, let the user know they can run it at any time to configure. Resolve and apply throughout the session (defaults in parens):
+2. Load available config from `{project-root}/_bmad/config.yaml` and `{project-root}/_bmad/config.user.yaml` (root and bmb section). If neither exists, fall back to `{project-root}/_bmad/bmb/config.yaml` (legacy per-module format). If still missing, and the `bmad-builder-setup` skill is available, let the user know they can run it at any time to configure. Resolve and apply throughout the session (defaults in parens):
    - `{user_name}` (default: null) — address the user by name
    - `{communication_language}` (default: user or system intent) — use for all communications
    - `{document_output_language}` (default: user or system intent) — use for generated document content

--- a/skills/bmad-module-builder/SKILL.md
+++ b/skills/bmad-module-builder/SKILL.md
@@ -17,7 +17,7 @@ This skill helps you bring BMad modules to life — from the first spark of an i
 
 ## On Activation
 
-Load available config from `{project-root}/_bmad/config.yaml` and `{project-root}/_bmad/config.user.yaml` (root level and `bmb` section). If config is missing, let the user know `bmad-builder-setup` can configure the module at any time. Use sensible defaults for anything not configured.
+Load available config from `{project-root}/_bmad/config.yaml` and `{project-root}/_bmad/config.user.yaml` (root level and `bmb` section). If neither exists, fall back to `{project-root}/_bmad/bmb/config.yaml` (legacy per-module format). If still missing, let the user know `bmad-builder-setup` can configure the module at any time. Use sensible defaults for anything not configured.
 
 Detect user's intent:
 

--- a/skills/bmad-workflow-builder/SKILL.md
+++ b/skills/bmad-workflow-builder/SKILL.md
@@ -19,7 +19,7 @@ Act as an architect guide — walk users through conversational discovery to und
 
 1. Detect user's intent. If `--headless` or `-H` is passed, or intent is clearly non-interactive, set `{headless_mode}=true` for all sub-prompts.
 
-2. Load available config from `{project-root}/_bmad/config.yaml` and `{project-root}/_bmad/config.user.yaml` (root and bmb section). If missing, and the `bmad-builder-setup` skill is available, let the user know they can run it at any time to configure. Resolve and apply throughout the session (defaults in parens):
+2. Load available config from `{project-root}/_bmad/config.yaml` and `{project-root}/_bmad/config.user.yaml` (root and bmb section). If neither exists, fall back to `{project-root}/_bmad/bmb/config.yaml` (legacy per-module format). If still missing, and the `bmad-builder-setup` skill is available, let the user know they can run it at any time to configure. Resolve and apply throughout the session (defaults in parens):
    - `{user_name}` (default: null) — address the user by name
    - `{communication_language}` (default: user or system intent) — use for all communications
    - `{document_output_language}` (default: user or system intent) — use for generated document content


### PR DESCRIPTION
## Summary
- BMB skills (agent-builder, workflow-builder, module-builder) now fall back to `_bmad/bmb/config.yaml` when the unified config files don't exist
- Fixes config resolution when the installer writes configs in legacy per-module format

Closes bmad-code-org/BMAD-METHOD#2107

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
- Updated configuration loading documentation for Agent Builder, Module Builder, and Workflow Builder skills to reflect enhanced fallback behavior for configuration file discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->