### PR TITLE
docs(customization): mention bmad-customize in author-facing guides

### DIFF
--- a/docs/explanation/customization-for-authors.md
+++ b/docs/explanation/customization-for-authors.md
@@ -5,7 +5,7 @@ description: How to decide whether your skill should support end-user customizat
 
 Shipping a `customize.toml` is opt-in per skill. This is the author-side counterpart to [How to Customize BMad](https://docs.bmad-method.org/how-to/customize-bmad/), which covers the end-user view. Read that first if you haven't; it shows what users experience when they override a skill. This guide is about deciding whether to give them that surface at all.
 
-Downstream users don't hand-write TOML. BMad ships a core skill called `bmad-customize` that walks them through authoring overrides conversationally — it scans which skills are customizable, picks agent vs workflow scope, writes the override file, and verifies the merge. That affects the names and defaults you pick: a user being walked through `"set prd_template to your template path"` handles that fine; `tmpl_override` or `opt_2` makes the conversation awkward. Pick field names that read well out loud.
+Downstream users typically don't hand-write TOML. BMad ships a core skill called `bmad-customize` that walks them through authoring overrides conversationally — it scans which skills are customizable, picks agent vs workflow scope, writes the override file, and verifies the merge. Users who prefer to edit TOML directly still can, but the conversational flow is the default path. That affects the names and defaults you pick: a user being walked through `"set prd_template to your template path"` handles that fine; `tmpl_override` or `opt_2` makes the conversation awkward. Pick field names that read well out loud.
 
 ## The Problem
 

--- a/docs/explanation/customization-for-authors.md
+++ b/docs/explanation/customization-for-authors.md
@@ -5,6 +5,8 @@ description: How to decide whether your skill should support end-user customizat
 
 Shipping a `customize.toml` is opt-in per skill. This is the author-side counterpart to [How to Customize BMad](https://docs.bmad-method.org/how-to/customize-bmad/), which covers the end-user view. Read that first if you haven't; it shows what users experience when they override a skill. This guide is about deciding whether to give them that surface at all.
 
+Downstream users don't hand-write TOML. BMad ships a core skill called `bmad-customize` that walks them through authoring overrides conversationally — it scans which skills are customizable, picks agent vs workflow scope, writes the override file, and verifies the merge. That affects the names and defaults you pick: a user being walked through `"set prd_template to your template path"` handles that fine; `tmpl_override` or `opt_2` makes the conversation awkward. Pick field names that read well out loud.
+
 ## The Problem
 
 Every customization knob you ship is a promise. Users pin values to it, teams commit overrides to git, and future releases have to respect the shape you locked in. Over-exposing makes the skill harder to evolve and invites drift; under-exposing forces forks for changes that should have been a three-line TOML file.

--- a/docs/how-to/make-a-skill-customizable.md
+++ b/docs/how-to/make-a-skill-customizable.md
@@ -5,6 +5,8 @@ description: Opt your skill into end-user customization during the build, name y
 
 This guide walks through opting a skill into end-user customization during a build. You'll hit the opt-in moment in the builder, pick names for the scalars you expose, and verify an override actually fires. Read [Customization for Authors](/explanation/customization-for-authors.md) first if you haven't decided whether to opt in.
 
+Keep in mind that your users won't typically hand-write the override files you're enabling. The `bmad-customize` skill in BMad core walks them through authoring overrides conversationally. The names and defaults you pick here are what a user is walked through in that conversation, so pick scalar names that read well out loud.
+
 ## When to Use This
 
 - You're building a workflow or stateless agent and want to let teams/org users inject overrides
@@ -136,6 +138,7 @@ Users get:
 - Team-scoped overrides via `_bmad/custom/{skill-name}.toml`
 - Personal-scoped overrides via `_bmad/custom/{skill-name}.user.toml`
 - Automatic precedence handling from the resolver (user beats team beats defaults)
+- A conversational authoring path: the `bmad-customize` core skill scans which skills are customizable, helps the user pick agent vs workflow scope, writes the override file, and verifies the merge. Users who prefer to hand-write TOML still can.
 
 ## Tips
 


### PR DESCRIPTION
## Summary

- Updates the two author-facing customization docs in bmb to point at `bmad-customize` (BMad core) as the downstream authoring path. Authors opting a skill into customization now know their users won't typically hand-write TOML — they'll walk through a conversational flow — so scalar names and defaults should read well out loud.

## Why

[BMAD-METHOD#2289](https://github.com/bmad-code-org/BMAD-METHOD/pull/2289) added `bmad-customize`, a core skill that scans customizable skills in a project, picks agent-vs-workflow scope, writes the override file to `_bmad/custom/`, and verifies the merge. Until now the author-side docs framed customization as "users will edit TOML" — that's no longer the primary path, and the shift affects naming judgment (a user being told "set `prd_template` to your template path" handles that fine; `tmpl_override` or `opt_2` makes the conversation awkward).

## Changes

- `docs/explanation/customization-for-authors.md` — intro paragraph describing the `bmad-customize` authoring flow and what it implies for field naming.
- `docs/how-to/make-a-skill-customizable.md` — intro note + new bullet in the "What You Get" user-experience list.

Docs only. No changes to skills, workflows, or scripts.

## Test plan

- [x] No code changes; existing docs build should be unaffected.
- [ ] Reviewer: confirm the wording feels aligned with the existing voice of the two docs (especially the "three questions" tone in `customization-for-authors.md`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how users customize skills through conversational workflows rather than manual file editing.
  * Added guidance for authors on selecting field names to ensure generated customization prompts read naturally in conversation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->