### PR TITLE
refactor(catalog): rename after/before to preceded-by/followed-by

### DIFF
--- a/skills/module-help.csv
+++ b/skills/module-help.csv
@@ -1,4 +1,4 @@
-module,skill,display-name,menu-code,description,action,args,phase,after,before,required,output-location,outputs
+module,skill,display-name,menu-code,description,action,args,phase,preceded-by,followed-by,required,output-location,outputs
 BMad Builder,_meta,,,,,,,,,false,https://bmad-builder-docs.bmad-method.org/llms.txt,
 BMad Builder,bmad-bmb-setup,Setup Builder Module,SB,"Install or update BMad Builder module config and help entries.",configure,"{-H: headless mode}|{inline values: skip prompts with provided values}",anytime,,,false,{project-root}/_bmad,config.yaml and config.user.yaml
 BMad Builder,bmad-agent-builder,Build an Agent,BA,"Create, edit, or rebuild an agent skill through conversational discovery.",build-process,"{-H: headless mode}|{description: initial agent concept}|{path: existing agent to edit or rebuild}",anytime,,bmad-agent-builder:quality-analysis,false,bmad_builder_output_folder,agent skill


### PR DESCRIPTION
## Summary

Header-only rename of `skills/module-help.csv` columns 9 and 10 from `after`/`before` to `preceded-by`/`followed-by`, aligning bmad-builder with the canonical schema shipped in bmad-code-org/BMAD-METHOD#2360.

## Why

The bare prepositions had no subject anchor — "X has Y in its `after` column" reads plausibly as either "Y comes after X" or "X comes after Y". An LLM consumer recently flipped the direction because of it; passive-voice participles ("X is preceded by Y") force a single reading.

## Scope

- Single line changed (header only) in `skills/module-help.csv`.
- Data rows are positionally identical and the upstream merger loads them unchanged regardless of header — this is purely a label rename.
- Without this rename, BMAD-METHOD v6.6.1+ installs emit an advisory warning naming this module on every install.

## Test plan

- [x] `npm run lint:md` and `npm run format:check` pass locally
- [ ] `npm run lint` has 6 pre-existing errors on `main` (in `tools/validate-doc-links.cjs` and one yaml file) that are unrelated to this change. They reproduce on `main` with the unmodified tree. Out of scope here; happy to file a separate cleanup PR if useful.
- [ ] Reviewer: confirm no local consumer in this repo reads the CSV by column name (none expected — the merger is in BMAD-METHOD)
