### PR TITLE
docs(changelog): add v1.8.1 entry for module-help.csv header rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.8.1] - 2026-05-17
+
+### 🐛 Fixes
+
+* **Module help catalog header alignment** — Renamed `after`/`before` columns in all `module-help.csv` files (module-level, setup-skill, builder template, samples) to `preceded-by`/`followed-by` to match the canonical 13-column schema introduced in BMAD-METHOD v6.6.0. Warning-only fix; data was already loaded positionally (#89).
+
 ## [1.8.0] - 2026-05-10
 
 ### 🎁 Features


### PR DESCRIPTION
## Summary

- Adds the missing v1.8.1 changelog entry so the release workflow can publish the GitHub Release for tag `v1.8.1` (already pushed by the release run that failed at the "Create GitHub Release" step).
- Documents the `after`/`before` → `preceded-by`/`followed-by` rename from #89.

## Test plan

- [ ] Merge this PR.
- [ ] Manually create the GitHub Release for the existing `v1.8.1` tag with these notes (no workflow re-run, since tag/version-commit already exist).