### PR TITLE
docs: remove bmad-distillator references from eval docs

### DIFF
--- a/docs/explanation/why-bmad-eval-runner.md
+++ b/docs/explanation/why-bmad-eval-runner.md
@@ -13,7 +13,7 @@ Why this matters: skills are sensitive to context. Your global `~/.claude/CLAUDE
 
 ## Dependency Staging
 
-Real BMad skills compose. A product brief skill calls a distillator skill, which calls editorial review skills. The runner stages dependencies through a setup overlay system: directories at `evals/setup/` (base, applied to every eval) and `evals/<eval-id>/setup/` (per-eval, applied on top) are rsynced into the workspace before the skill under test is staged.
+Real BMad skills compose. A product brief skill calls editorial review skills, which surface improvement suggestions. The runner stages dependencies through a setup overlay system: directories at `evals/setup/` (base, applied to every eval) and `evals/<eval-id>/setup/` (per-eval, applied on top) are rsynced into the workspace before the skill under test is staged.
 
 Drop the dependency skills into `evals/setup/.claude/skills/` and they are available inside the sandbox. Drop a per-eval `_bmad/config.user.yaml` into `evals/C1/setup/` and it overrides the base for that eval only.
 

--- a/docs/reference/eval-format.md
+++ b/docs/reference/eval-format.md
@@ -16,7 +16,7 @@ evals/<skill-name>/
 ├── setup/                # Base overlay applied to every eval
 │   └── .claude/
 │       └── skills/
-│           └── bmad-distillator/
+│           └── bmad-editorial-review-prose/
 ├── A1/
 │   └── setup/            # Per-eval overlay applied on top of base
 ├── files/                # Fixture files staged via the eval's `files` field
@@ -73,13 +73,13 @@ Each entry in `files` is staged into the eval's workspace before execution.
 
 ### Per-Eval Timeout
 
-When omitted, the runner's default applies (currently 600 seconds, overridable via `--timeout`). Set per-eval timeouts when an eval invokes a slow dependency. Example for an eval that triggers a distillator subagent:
+When omitted, the runner's default applies (currently 600 seconds, overridable via `--timeout`). Set per-eval timeouts when an eval invokes a slow dependency. Example for an eval that triggers a long-running subagent:
 
 ```json
 {
   "id": "B8",
   "timeout": 900,
-  "prompt": "Run headless. Create a product brief ... and generate a distillate."
+  "prompt": "Run headless. Create a product brief ... and run editorial polish."
 }
 ```
 
@@ -130,7 +130,6 @@ Files at `evals/<skill-name>/setup/` are applied to every eval. Use this for dep
 evals/bmad-product-brief/setup/
 └── .claude/
     └── skills/
-        ├── bmad-distillator/
         ├── bmad-editorial-review-prose/
         └── bmad-editorial-review-structure/
 ```
@@ -193,15 +192,15 @@ The `bmad-product-brief` skill in the BMad Method repository ships a complete ev
 | Group | What It Covers                                                                                       |
 | ----- | ---------------------------------------------------------------------------------------------------- |
 | A1-A8 | Output grading: brief content, frontmatter, source-filtering, right-sizing across 8 product scenarios |
-| B1-B8 | Transcript grading: decision-log fidelity, polish phase ordering, read-only Validate, distillate flow |
+| B1-B8 | Transcript grading: decision-log fidelity, polish phase ordering, read-only Validate                |
 | C1    | Configuration compliance: custom output paths, document language, communication style                 |
 | Triggers | 15 queries (positive + negative) covering create, update, validate intents and adjacent skills      |
 
 What it shows in practice:
 
-- Setup overlays for dependency skills (`bmad-distillator`, editorial review skills) under `evals/setup/.claude/skills/`
+- Setup overlays for dependency skills (editorial review skills) under `evals/setup/.claude/skills/`
 - Per-eval setup overlay at `evals/bmad-product-brief/C1/setup/_bmad/` for custom configuration
-- Per-eval `timeout` override on B8 (the distillator-invoking eval)
+- Per-eval `timeout` override on B8 (the slowest scenario)
 - Read-only fixture staging for Validate-mode evals (A4, B5, B6, B7) using the `files` field
 - Mixed expectations in the same eval: some assertions check files, others scan the transcript for tool-call ordering
 


### PR DESCRIPTION
## Summary

`bmad-distillator` is being retired in [bmad-code-org/BMAD-METHOD#2417](https://github.com/bmad-code-org/BMAD-METHOD/pull/2417), superseded by the new `bmad-spec` skill. This PR updates the bmb docs so they stop pointing at a skill that will no longer exist.

- `docs/explanation/why-bmad-eval-runner.md`: simplify the composition example to drop the distillator step
- `docs/reference/eval-format.md`: replace distillator with editorial review skills in the setup-overlay tree, generalize the per-eval timeout example, drop "distillate flow" and the "distillator-invoking eval" phrasing from the bmad-product-brief example suite walkthrough

Purely a docs change.

## Test plan

- [ ] Visually skim the rendered docs to confirm the surrounding prose still reads cleanly
- [ ] Confirm no remaining `bmad-distillator` references in `docs/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated eval runner documentation to reflect current skill composition and naming conventions.
  * Removed outdated skill references and updated examples to match the current setup workflow.
  * Clarified descriptions of eval suite timeout configurations and transcript grading processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bmad-code-org/bmad-builder/pull/91?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->