### PR TITLE
fix(setup): resolve {project-root} in script path arguments

### DIFF
--- a/samples/bmad-agent-dream-weaver/assets/module-setup.md
+++ b/samples/bmad-agent-dream-weaver/assets/module-setup.md
@@ -12,7 +12,7 @@ Registers this standalone module into a project. Module identity (name, code, ve
 
 Both config scripts use an anti-zombie pattern — existing entries for this module are removed before writing fresh ones, so stale values never persist.
 
-`{project-root}` is a **literal token** in config values — never substitute it with an actual path. It signals to the consuming LLM that the value is relative to the project root, not the skill root.
+`{project-root}` is a **literal token** in config _values_ (the data written into the files above) — never substitute it there. It signals to the consuming LLM that the value is relative to the project root, not the skill root. **This does not apply to the filesystem path _arguments_ passed to the scripts below** (the `--*-path`, `--*-dir`, and `--target` arguments): those are real paths, so you **must** resolve `{project-root}` to the actual project root before running, or the scripts will write to a literal `{project-root}/` directory under the skill folder. The scripts reject an unresolved token with an error.
 
 ## Check Existing Config
 
@@ -48,7 +48,9 @@ Ask using the prompt with its default value. Apply `result` templates when stori
 
 ## Write Files
 
-Write a temp JSON file with the collected answers structured as `{"core": {...}, "module": {...}}` (omit `core` if it already exists). Then run both scripts — they can run in parallel since they write to different files:
+Write a temp JSON file with the collected answers structured as `{"core": {...}, "module": {...}}` (omit `core` if it already exists). Values inside this JSON keep the literal `{project-root}` token. Then run both scripts — they can run in parallel since they write to different files.
+
+In the commands below, replace `{project-root}` in every path argument with the actual project root (e.g. `/home/me/myapp`) before running — these are filesystem paths, not config values.
 
 ```bash
 python3 ./scripts/merge-config.py --config-path "{project-root}/_bmad/config.yaml" --user-config-path "{project-root}/_bmad/config.user.yaml" --module-yaml ./assets/module.yaml --answers {temp-file}

--- a/samples/bmad-agent-dream-weaver/scripts/merge-config.py
+++ b/samples/bmad-agent-dream-weaver/scripts/merge-config.py
@@ -339,8 +339,40 @@ def write_config(config: dict, config_path: str, verbose: bool = False) -> None:
         )
 
 
+def reject_unresolved_paths(named_paths: list[tuple[str, str]]) -> None:
+    """Exit with a clear error if any path argument still contains the literal
+    ``{project-root}`` token. That token is meaningful only inside config
+    values; filesystem path arguments must be resolved by the caller. Failing
+    loudly here prevents silently creating a junk ``{project-root}/`` directory.
+    """
+    for name, value in named_paths:
+        if value and "{project-root}" in value:
+            print(
+                json.dumps(
+                    {
+                        "status": "error",
+                        "error": (
+                            f"Unresolved '{{project-root}}' token in {name} path: {value!r}. "
+                            "Resolve '{project-root}' to the actual project root before running "
+                            "this script — it is a filesystem path, not a config value."
+                        ),
+                    },
+                    indent=2,
+                )
+            )
+            sys.exit(1)
+
+
 def main():
     args = parse_args()
+
+    reject_unresolved_paths(
+        [
+            ("--config-path", args.config_path),
+            ("--user-config-path", args.user_config_path),
+            ("--legacy-dir", args.legacy_dir),
+        ]
+    )
 
     # Load inputs
     module_yaml = load_yaml_file(args.module_yaml)

--- a/samples/bmad-agent-dream-weaver/scripts/merge-config.py
+++ b/samples/bmad-agent-dream-weaver/scripts/merge-config.py
@@ -358,7 +358,8 @@ def reject_unresolved_paths(named_paths: list[tuple[str, str]]) -> None:
                         ),
                     },
                     indent=2,
-                )
+                ),
+                file=sys.stderr,
             )
             sys.exit(1)
 

--- a/samples/bmad-agent-dream-weaver/scripts/merge-help-csv.py
+++ b/samples/bmad-agent-dream-weaver/scripts/merge-help-csv.py
@@ -139,8 +139,36 @@ def cleanup_legacy_csvs(
     return deleted
 
 
+def reject_unresolved_paths(named_paths: list[tuple[str, str]]) -> None:
+    """Exit with a clear error if any path argument still contains the literal
+    ``{project-root}`` token. That token is meaningful only inside config
+    values; filesystem path arguments must be resolved by the caller. Failing
+    loudly here prevents silently creating a junk ``{project-root}/`` directory.
+    """
+    for name, value in named_paths:
+        if value and "{project-root}" in value:
+            print(
+                json.dumps(
+                    {
+                        "status": "error",
+                        "error": (
+                            f"Unresolved '{{project-root}}' token in {name} path: {value!r}. "
+                            "Resolve '{project-root}' to the actual project root before running "
+                            "this script — it is a filesystem path, not a config value."
+                        ),
+                    },
+                    indent=2,
+                )
+            )
+            sys.exit(1)
+
+
 def main():
     args = parse_args()
+
+    reject_unresolved_paths(
+        [("--target", args.target), ("--legacy-dir", args.legacy_dir)]
+    )
 
     # Read source entries
     source_header, source_rows = read_csv_rows(args.source)

--- a/samples/sample-module-setup/SKILL.md
+++ b/samples/sample-module-setup/SKILL.md
@@ -15,7 +15,7 @@ Installs and configures a BMad module into a project. Module identity (name, cod
 
 Both config scripts use an anti-zombie pattern — existing entries for this module are removed before writing fresh ones, so stale values never persist.
 
-`{project-root}` is a **literal token** in config values — never substitute it with an actual path. It signals to the consuming LLM that the value is relative to the project root, not the skill root.
+`{project-root}` is a **literal token** in config _values_ (the data written into the files above) — never substitute it there. It signals to the consuming LLM that the value is relative to the project root, not the skill root. **This does not apply to the filesystem path _arguments_ passed to the scripts below** (the `--*-path`, `--*-dir`, and `--target` arguments): those are real paths, so you **must** resolve `{project-root}` to the actual project root before running, or the scripts will write to a literal `{project-root}/` directory under the skill folder. The scripts reject an unresolved token with an error.
 
 ## On Activation
 
@@ -40,7 +40,9 @@ Ask the user for values. Show defaults in brackets. Present all values together 
 
 ## Write Files
 
-Write a temp JSON file with the collected answers structured as `{"core": {...}, "module": {...}}` (omit `core` if it already exists). Then run both scripts — they can run in parallel since they write to different files:
+Write a temp JSON file with the collected answers structured as `{"core": {...}, "module": {...}}` (omit `core` if it already exists). Values inside this JSON keep the literal `{project-root}` token. Then run both scripts — they can run in parallel since they write to different files.
+
+In the commands below, replace `{project-root}` in every path argument with the actual project root (e.g. `/home/me/myapp`) before running — these are filesystem paths, not config values.
 
 ```bash
 python3 ./scripts/merge-config.py --config-path "{project-root}/_bmad/config.yaml" --user-config-path "{project-root}/_bmad/config.user.yaml" --module-yaml ./assets/module.yaml --answers {temp-file} --legacy-dir "{project-root}/_bmad"
@@ -58,6 +60,8 @@ After writing config, create any output directories that were configured. For fi
 ## Cleanup Legacy Directories
 
 After both merge scripts complete successfully, remove the installer's package directories. Skills and agents in these directories are already installed at `.claude/skills/` — the `_bmad/` directory should only contain config files.
+
+As with the merge scripts, replace `{project-root}` in the `--bmad-dir` and `--skills-dir` path arguments with the actual project root before running.
 
 ```bash
 python3 ./scripts/cleanup-legacy.py --bmad-dir "{project-root}/_bmad" --module-code sam --also-remove _config --skills-dir "{project-root}/.claude/skills"

--- a/samples/sample-module-setup/scripts/cleanup-legacy.py
+++ b/samples/sample-module-setup/scripts/cleanup-legacy.py
@@ -197,8 +197,36 @@ def cleanup_directories(
     return removed, not_found, total_files
 
 
+def reject_unresolved_paths(named_paths: list[tuple[str, str]]) -> None:
+    """Exit with a clear error if any path argument still contains the literal
+    ``{project-root}`` token. That token is meaningful only inside config
+    values; filesystem path arguments must be resolved by the caller. Failing
+    loudly here prevents silently operating on a junk ``{project-root}/`` directory.
+    """
+    for name, value in named_paths:
+        if value and "{project-root}" in value:
+            print(
+                json.dumps(
+                    {
+                        "status": "error",
+                        "error": (
+                            f"Unresolved '{{project-root}}' token in {name} path: {value!r}. "
+                            "Resolve '{project-root}' to the actual project root before running "
+                            "this script — it is a filesystem path, not a config value."
+                        ),
+                    },
+                    indent=2,
+                )
+            )
+            sys.exit(1)
+
+
 def main():
     args = parse_args()
+
+    reject_unresolved_paths(
+        [("--bmad-dir", args.bmad_dir), ("--skills-dir", args.skills_dir)]
+    )
 
     bmad_dir = args.bmad_dir
     module_code = args.module_code

--- a/samples/sample-module-setup/scripts/merge-config.py
+++ b/samples/sample-module-setup/scripts/merge-config.py
@@ -339,8 +339,40 @@ def write_config(config: dict, config_path: str, verbose: bool = False) -> None:
         )
 
 
+def reject_unresolved_paths(named_paths: list[tuple[str, str]]) -> None:
+    """Exit with a clear error if any path argument still contains the literal
+    ``{project-root}`` token. That token is meaningful only inside config
+    values; filesystem path arguments must be resolved by the caller. Failing
+    loudly here prevents silently creating a junk ``{project-root}/`` directory.
+    """
+    for name, value in named_paths:
+        if value and "{project-root}" in value:
+            print(
+                json.dumps(
+                    {
+                        "status": "error",
+                        "error": (
+                            f"Unresolved '{{project-root}}' token in {name} path: {value!r}. "
+                            "Resolve '{project-root}' to the actual project root before running "
+                            "this script — it is a filesystem path, not a config value."
+                        ),
+                    },
+                    indent=2,
+                )
+            )
+            sys.exit(1)
+
+
 def main():
     args = parse_args()
+
+    reject_unresolved_paths(
+        [
+            ("--config-path", args.config_path),
+            ("--user-config-path", args.user_config_path),
+            ("--legacy-dir", args.legacy_dir),
+        ]
+    )
 
     # Load inputs
     module_yaml = load_yaml_file(args.module_yaml)

--- a/samples/sample-module-setup/scripts/merge-config.py
+++ b/samples/sample-module-setup/scripts/merge-config.py
@@ -358,7 +358,8 @@ def reject_unresolved_paths(named_paths: list[tuple[str, str]]) -> None:
                         ),
                     },
                     indent=2,
-                )
+                ),
+                file=sys.stderr,
             )
             sys.exit(1)
 

--- a/samples/sample-module-setup/scripts/merge-help-csv.py
+++ b/samples/sample-module-setup/scripts/merge-help-csv.py
@@ -139,8 +139,36 @@ def cleanup_legacy_csvs(
     return deleted
 
 
+def reject_unresolved_paths(named_paths: list[tuple[str, str]]) -> None:
+    """Exit with a clear error if any path argument still contains the literal
+    ``{project-root}`` token. That token is meaningful only inside config
+    values; filesystem path arguments must be resolved by the caller. Failing
+    loudly here prevents silently creating a junk ``{project-root}/`` directory.
+    """
+    for name, value in named_paths:
+        if value and "{project-root}" in value:
+            print(
+                json.dumps(
+                    {
+                        "status": "error",
+                        "error": (
+                            f"Unresolved '{{project-root}}' token in {name} path: {value!r}. "
+                            "Resolve '{project-root}' to the actual project root before running "
+                            "this script — it is a filesystem path, not a config value."
+                        ),
+                    },
+                    indent=2,
+                )
+            )
+            sys.exit(1)
+
+
 def main():
     args = parse_args()
+
+    reject_unresolved_paths(
+        [("--target", args.target), ("--legacy-dir", args.legacy_dir)]
+    )
 
     # Read source entries
     source_header, source_rows = read_csv_rows(args.source)

--- a/skills/bmad-bmb-setup/SKILL.md
+++ b/skills/bmad-bmb-setup/SKILL.md
@@ -15,7 +15,7 @@ Installs and configures a BMad module into a project. Module identity (name, cod
 
 Both config scripts use an anti-zombie pattern — existing entries for this module are removed before writing fresh ones, so stale values never persist.
 
-`{project-root}` is a **literal token** in config values — never substitute it with an actual path. It signals to the consuming LLM that the value is relative to the project root, not the skill root.
+`{project-root}` is a **literal token** in config _values_ (the data written into the files above) — never substitute it there. It signals to the consuming LLM that the value is relative to the project root, not the skill root. **This does not apply to filesystem path _arguments_ passed to the scripts below** (`--target`, `--config-path`, `--user-config-path`, `--legacy-dir`, `--bmad-dir`, `--skills-dir`): those are real paths, so you **must** resolve `{project-root}` to the actual project root before running, or the scripts will write to a literal `{project-root}/` directory under the skill folder. The scripts reject an unresolved token with an error.
 
 ## On Activation
 
@@ -40,7 +40,9 @@ Ask the user for values. Show defaults in brackets. Present all values together 
 
 ## Write Files
 
-Write a temp JSON file with the collected answers structured as `{"core": {...}, "module": {...}}` (omit `core` if it already exists). Then run both scripts — they can run in parallel since they write to different files:
+Write a temp JSON file with the collected answers structured as `{"core": {...}, "module": {...}}` (omit `core` if it already exists). Values inside this JSON keep the literal `{project-root}` token. Then run both scripts — they can run in parallel since they write to different files.
+
+In the commands below, replace `{project-root}` in every path argument with the actual project root (e.g. `/home/me/myapp`) before running — these are filesystem paths, not config values. Leave `{temp-file}` and `bmb` as-is.
 
 ```bash
 python3 ./scripts/merge-config.py --config-path "{project-root}/_bmad/config.yaml" --user-config-path "{project-root}/_bmad/config.user.yaml" --module-yaml ./assets/module.yaml --answers {temp-file} --legacy-dir "{project-root}/_bmad"
@@ -58,6 +60,8 @@ After writing config, create any output directories that were configured. For fi
 ## Cleanup Legacy Directories
 
 After both merge scripts complete successfully, remove the installer's package directories. Skills and agents in these directories are already installed at `.claude/skills/` — the `_bmad/` directory should only contain config files.
+
+As with the merge scripts, replace `{project-root}` in the `--bmad-dir` and `--skills-dir` path arguments with the actual project root before running.
 
 ```bash
 python3 ./scripts/cleanup-legacy.py --bmad-dir "{project-root}/_bmad" --module-code bmb --also-remove _config --skills-dir "{project-root}/.claude/skills"

--- a/skills/bmad-bmb-setup/scripts/cleanup-legacy.py
+++ b/skills/bmad-bmb-setup/scripts/cleanup-legacy.py
@@ -197,8 +197,36 @@ def cleanup_directories(
     return removed, not_found, total_files
 
 
+def reject_unresolved_paths(named_paths: list[tuple[str, str]]) -> None:
+    """Exit with a clear error if any path argument still contains the literal
+    ``{project-root}`` token. That token is meaningful only inside config
+    values; filesystem path arguments must be resolved by the caller. Failing
+    loudly here prevents silently operating on a junk ``{project-root}/`` directory.
+    """
+    for name, value in named_paths:
+        if value and "{project-root}" in value:
+            print(
+                json.dumps(
+                    {
+                        "status": "error",
+                        "error": (
+                            f"Unresolved '{{project-root}}' token in {name} path: {value!r}. "
+                            "Resolve '{project-root}' to the actual project root before running "
+                            "this script — it is a filesystem path, not a config value."
+                        ),
+                    },
+                    indent=2,
+                )
+            )
+            sys.exit(1)
+
+
 def main():
     args = parse_args()
+
+    reject_unresolved_paths(
+        [("--bmad-dir", args.bmad_dir), ("--skills-dir", args.skills_dir)]
+    )
 
     bmad_dir = args.bmad_dir
     module_code = args.module_code

--- a/skills/bmad-bmb-setup/scripts/merge-config.py
+++ b/skills/bmad-bmb-setup/scripts/merge-config.py
@@ -339,8 +339,40 @@ def write_config(config: dict, config_path: str, verbose: bool = False) -> None:
         )
 
 
+def reject_unresolved_paths(named_paths: list[tuple[str, str]]) -> None:
+    """Exit with a clear error if any path argument still contains the literal
+    ``{project-root}`` token. That token is meaningful only inside config
+    values; filesystem path arguments must be resolved by the caller. Failing
+    loudly here prevents silently creating a junk ``{project-root}/`` directory.
+    """
+    for name, value in named_paths:
+        if value and "{project-root}" in value:
+            print(
+                json.dumps(
+                    {
+                        "status": "error",
+                        "error": (
+                            f"Unresolved '{{project-root}}' token in {name} path: {value!r}. "
+                            "Resolve '{project-root}' to the actual project root before running "
+                            "this script — it is a filesystem path, not a config value."
+                        ),
+                    },
+                    indent=2,
+                )
+            )
+            sys.exit(1)
+
+
 def main():
     args = parse_args()
+
+    reject_unresolved_paths(
+        [
+            ("--config-path", args.config_path),
+            ("--user-config-path", args.user_config_path),
+            ("--legacy-dir", args.legacy_dir),
+        ]
+    )
 
     # Load inputs
     module_yaml = load_yaml_file(args.module_yaml)

--- a/skills/bmad-bmb-setup/scripts/merge-config.py
+++ b/skills/bmad-bmb-setup/scripts/merge-config.py
@@ -358,7 +358,8 @@ def reject_unresolved_paths(named_paths: list[tuple[str, str]]) -> None:
                         ),
                     },
                     indent=2,
-                )
+                ),
+                file=sys.stderr,
             )
             sys.exit(1)
 

--- a/skills/bmad-bmb-setup/scripts/merge-help-csv.py
+++ b/skills/bmad-bmb-setup/scripts/merge-help-csv.py
@@ -139,8 +139,36 @@ def cleanup_legacy_csvs(
     return deleted
 
 
+def reject_unresolved_paths(named_paths: list[tuple[str, str]]) -> None:
+    """Exit with a clear error if any path argument still contains the literal
+    ``{project-root}`` token. That token is meaningful only inside config
+    values; filesystem path arguments must be resolved by the caller. Failing
+    loudly here prevents silently creating a junk ``{project-root}/`` directory.
+    """
+    for name, value in named_paths:
+        if value and "{project-root}" in value:
+            print(
+                json.dumps(
+                    {
+                        "status": "error",
+                        "error": (
+                            f"Unresolved '{{project-root}}' token in {name} path: {value!r}. "
+                            "Resolve '{project-root}' to the actual project root before running "
+                            "this script — it is a filesystem path, not a config value."
+                        ),
+                    },
+                    indent=2,
+                )
+            )
+            sys.exit(1)
+
+
 def main():
     args = parse_args()
+
+    reject_unresolved_paths(
+        [("--target", args.target), ("--legacy-dir", args.legacy_dir)]
+    )
 
     # Read source entries
     source_header, source_rows = read_csv_rows(args.source)

--- a/skills/bmad-module-builder/assets/setup-skill-template/SKILL.md
+++ b/skills/bmad-module-builder/assets/setup-skill-template/SKILL.md
@@ -15,7 +15,7 @@ Installs and configures a BMad module into a project. Module identity (name, cod
 
 Both config scripts use an anti-zombie pattern — existing entries for this module are removed before writing fresh ones, so stale values never persist.
 
-`{project-root}` is a **literal token** in config values — never substitute it with an actual path. It signals to the consuming LLM that the value is relative to the project root, not the skill root.
+`{project-root}` is a **literal token** in config _values_ (the data written into the files above) — never substitute it there. It signals to the consuming LLM that the value is relative to the project root, not the skill root. **This does not apply to the filesystem path _arguments_ passed to the scripts below** (the `--*-path`, `--*-dir`, and `--target` arguments): those are real paths, so you **must** resolve `{project-root}` to the actual project root before running, or the scripts will write to a literal `{project-root}/` directory under the skill folder. The scripts reject an unresolved token with an error.
 
 ## On Activation
 
@@ -40,7 +40,9 @@ Ask the user for values. Show defaults in brackets. Present all values together 
 
 ## Write Files
 
-Write a temp JSON file with the collected answers structured as `{"core": {...}, "module": {...}}` (omit `core` if it already exists). Then run both scripts — they can run in parallel since they write to different files:
+Write a temp JSON file with the collected answers structured as `{"core": {...}, "module": {...}}` (omit `core` if it already exists). Values inside this JSON keep the literal `{project-root}` token. Then run both scripts — they can run in parallel since they write to different files.
+
+In the commands below, replace `{project-root}` in every path argument with the actual project root (e.g. `/home/me/myapp`) before running — these are filesystem paths, not config values.
 
 ```bash
 python3 ./scripts/merge-config.py --config-path "{project-root}/_bmad/config.yaml" --user-config-path "{project-root}/_bmad/config.user.yaml" --module-yaml ./assets/module.yaml --answers {temp-file} --legacy-dir "{project-root}/_bmad"
@@ -58,6 +60,8 @@ After writing config, create any output directories that were configured. For fi
 ## Cleanup Legacy Directories
 
 After both merge scripts complete successfully, remove the installer's package directories. Skills and agents in these directories are already installed at `.claude/skills/` — the `_bmad/` directory should only contain config files.
+
+As with the merge scripts, replace `{project-root}` in the `--bmad-dir` and `--skills-dir` path arguments with the actual project root before running.
 
 ```bash
 python3 ./scripts/cleanup-legacy.py --bmad-dir "{project-root}/_bmad" --module-code {module-code} --also-remove _config --skills-dir "{project-root}/.claude/skills"

--- a/skills/bmad-module-builder/assets/setup-skill-template/scripts/cleanup-legacy.py
+++ b/skills/bmad-module-builder/assets/setup-skill-template/scripts/cleanup-legacy.py
@@ -197,8 +197,36 @@ def cleanup_directories(
     return removed, not_found, total_files
 
 
+def reject_unresolved_paths(named_paths: list[tuple[str, str]]) -> None:
+    """Exit with a clear error if any path argument still contains the literal
+    ``{project-root}`` token. That token is meaningful only inside config
+    values; filesystem path arguments must be resolved by the caller. Failing
+    loudly here prevents silently operating on a junk ``{project-root}/`` directory.
+    """
+    for name, value in named_paths:
+        if value and "{project-root}" in value:
+            print(
+                json.dumps(
+                    {
+                        "status": "error",
+                        "error": (
+                            f"Unresolved '{{project-root}}' token in {name} path: {value!r}. "
+                            "Resolve '{project-root}' to the actual project root before running "
+                            "this script — it is a filesystem path, not a config value."
+                        ),
+                    },
+                    indent=2,
+                )
+            )
+            sys.exit(1)
+
+
 def main():
     args = parse_args()
+
+    reject_unresolved_paths(
+        [("--bmad-dir", args.bmad_dir), ("--skills-dir", args.skills_dir)]
+    )
 
     bmad_dir = args.bmad_dir
     module_code = args.module_code

--- a/skills/bmad-module-builder/assets/setup-skill-template/scripts/merge-config.py
+++ b/skills/bmad-module-builder/assets/setup-skill-template/scripts/merge-config.py
@@ -339,8 +339,40 @@ def write_config(config: dict, config_path: str, verbose: bool = False) -> None:
         )
 
 
+def reject_unresolved_paths(named_paths: list[tuple[str, str]]) -> None:
+    """Exit with a clear error if any path argument still contains the literal
+    ``{project-root}`` token. That token is meaningful only inside config
+    values; filesystem path arguments must be resolved by the caller. Failing
+    loudly here prevents silently creating a junk ``{project-root}/`` directory.
+    """
+    for name, value in named_paths:
+        if value and "{project-root}" in value:
+            print(
+                json.dumps(
+                    {
+                        "status": "error",
+                        "error": (
+                            f"Unresolved '{{project-root}}' token in {name} path: {value!r}. "
+                            "Resolve '{project-root}' to the actual project root before running "
+                            "this script — it is a filesystem path, not a config value."
+                        ),
+                    },
+                    indent=2,
+                )
+            )
+            sys.exit(1)
+
+
 def main():
     args = parse_args()
+
+    reject_unresolved_paths(
+        [
+            ("--config-path", args.config_path),
+            ("--user-config-path", args.user_config_path),
+            ("--legacy-dir", args.legacy_dir),
+        ]
+    )
 
     # Load inputs
     module_yaml = load_yaml_file(args.module_yaml)

--- a/skills/bmad-module-builder/assets/setup-skill-template/scripts/merge-config.py
+++ b/skills/bmad-module-builder/assets/setup-skill-template/scripts/merge-config.py
@@ -358,7 +358,8 @@ def reject_unresolved_paths(named_paths: list[tuple[str, str]]) -> None:
                         ),
                     },
                     indent=2,
-                )
+                ),
+                file=sys.stderr,
             )
             sys.exit(1)
 

--- a/skills/bmad-module-builder/assets/setup-skill-template/scripts/merge-help-csv.py
+++ b/skills/bmad-module-builder/assets/setup-skill-template/scripts/merge-help-csv.py
@@ -139,8 +139,36 @@ def cleanup_legacy_csvs(
     return deleted
 
 
+def reject_unresolved_paths(named_paths: list[tuple[str, str]]) -> None:
+    """Exit with a clear error if any path argument still contains the literal
+    ``{project-root}`` token. That token is meaningful only inside config
+    values; filesystem path arguments must be resolved by the caller. Failing
+    loudly here prevents silently creating a junk ``{project-root}/`` directory.
+    """
+    for name, value in named_paths:
+        if value and "{project-root}" in value:
+            print(
+                json.dumps(
+                    {
+                        "status": "error",
+                        "error": (
+                            f"Unresolved '{{project-root}}' token in {name} path: {value!r}. "
+                            "Resolve '{project-root}' to the actual project root before running "
+                            "this script — it is a filesystem path, not a config value."
+                        ),
+                    },
+                    indent=2,
+                )
+            )
+            sys.exit(1)
+
+
 def main():
     args = parse_args()
+
+    reject_unresolved_paths(
+        [("--target", args.target), ("--legacy-dir", args.legacy_dir)]
+    )
 
     # Read source entries
     source_header, source_rows = read_csv_rows(args.source)

--- a/skills/bmad-module-builder/assets/standalone-module-template/merge-config.py
+++ b/skills/bmad-module-builder/assets/standalone-module-template/merge-config.py
@@ -339,8 +339,40 @@ def write_config(config: dict, config_path: str, verbose: bool = False) -> None:
         )
 
 
+def reject_unresolved_paths(named_paths: list[tuple[str, str]]) -> None:
+    """Exit with a clear error if any path argument still contains the literal
+    ``{project-root}`` token. That token is meaningful only inside config
+    values; filesystem path arguments must be resolved by the caller. Failing
+    loudly here prevents silently creating a junk ``{project-root}/`` directory.
+    """
+    for name, value in named_paths:
+        if value and "{project-root}" in value:
+            print(
+                json.dumps(
+                    {
+                        "status": "error",
+                        "error": (
+                            f"Unresolved '{{project-root}}' token in {name} path: {value!r}. "
+                            "Resolve '{project-root}' to the actual project root before running "
+                            "this script — it is a filesystem path, not a config value."
+                        ),
+                    },
+                    indent=2,
+                )
+            )
+            sys.exit(1)
+
+
 def main():
     args = parse_args()
+
+    reject_unresolved_paths(
+        [
+            ("--config-path", args.config_path),
+            ("--user-config-path", args.user_config_path),
+            ("--legacy-dir", args.legacy_dir),
+        ]
+    )
 
     # Load inputs
     module_yaml = load_yaml_file(args.module_yaml)

--- a/skills/bmad-module-builder/assets/standalone-module-template/merge-config.py
+++ b/skills/bmad-module-builder/assets/standalone-module-template/merge-config.py
@@ -358,7 +358,8 @@ def reject_unresolved_paths(named_paths: list[tuple[str, str]]) -> None:
                         ),
                     },
                     indent=2,
-                )
+                ),
+                file=sys.stderr,
             )
             sys.exit(1)
 

--- a/skills/bmad-module-builder/assets/standalone-module-template/merge-help-csv.py
+++ b/skills/bmad-module-builder/assets/standalone-module-template/merge-help-csv.py
@@ -139,8 +139,36 @@ def cleanup_legacy_csvs(
     return deleted
 
 
+def reject_unresolved_paths(named_paths: list[tuple[str, str]]) -> None:
+    """Exit with a clear error if any path argument still contains the literal
+    ``{project-root}`` token. That token is meaningful only inside config
+    values; filesystem path arguments must be resolved by the caller. Failing
+    loudly here prevents silently creating a junk ``{project-root}/`` directory.
+    """
+    for name, value in named_paths:
+        if value and "{project-root}" in value:
+            print(
+                json.dumps(
+                    {
+                        "status": "error",
+                        "error": (
+                            f"Unresolved '{{project-root}}' token in {name} path: {value!r}. "
+                            "Resolve '{project-root}' to the actual project root before running "
+                            "this script — it is a filesystem path, not a config value."
+                        ),
+                    },
+                    indent=2,
+                )
+            )
+            sys.exit(1)
+
+
 def main():
     args = parse_args()
+
+    reject_unresolved_paths(
+        [("--target", args.target), ("--legacy-dir", args.legacy_dir)]
+    )
 
     # Read source entries
     source_header, source_rows = read_csv_rows(args.source)

--- a/skills/bmad-module-builder/assets/standalone-module-template/module-setup.md
+++ b/skills/bmad-module-builder/assets/standalone-module-template/module-setup.md
@@ -15,7 +15,7 @@ Registers this standalone module into a project. Module identity (name, code, ve
 
 Both config scripts use an anti-zombie pattern — existing entries for this module are removed before writing fresh ones, so stale values never persist.
 
-`{project-root}` is a **literal token** in config values — never substitute it with an actual path. It signals to the consuming LLM that the value is relative to the project root, not the skill root.
+`{project-root}` is a **literal token** in config _values_ (the data written into the files above) — never substitute it there. It signals to the consuming LLM that the value is relative to the project root, not the skill root. **This does not apply to the filesystem path _arguments_ passed to the scripts below** (the `--*-path`, `--*-dir`, and `--target` arguments): those are real paths, so you **must** resolve `{project-root}` to the actual project root before running, or the scripts will write to a literal `{project-root}/` directory under the skill folder. The scripts reject an unresolved token with an error.
 
 ## Check Existing Config
 
@@ -51,7 +51,9 @@ Ask using the prompt with its default value. Apply `result` templates when stori
 
 ## Write Files
 
-Write a temp JSON file with the collected answers structured as `{"core": {...}, "module": {...}}` (omit `core` if it already exists). Then run both scripts — they can run in parallel since they write to different files:
+Write a temp JSON file with the collected answers structured as `{"core": {...}, "module": {...}}` (omit `core` if it already exists). Values inside this JSON keep the literal `{project-root}` token. Then run both scripts — they can run in parallel since they write to different files.
+
+In the commands below, replace `{project-root}` in every path argument with the actual project root (e.g. `/home/me/myapp`) before running — these are filesystem paths, not config values.
 
 ```bash
 python3 ./scripts/merge-config.py --config-path "{project-root}/_bmad/config.yaml" --user-config-path "{project-root}/_bmad/config.user.yaml" --module-yaml ./assets/module.yaml --answers {temp-file}


### PR DESCRIPTION
## Problem

The setup skill's `SKILL.md` instructed passing a **literal `{project-root}` token** as the filesystem *path arguments* to the merge/cleanup scripts (`--target`, `--config-path`, `--user-config-path`, `--legacy-dir`, `--bmad-dir`, `--skills-dir`), while line 18 also stated the token must "never be substituted with an actual path."

The scripts treat those arguments as real paths and create parent directories, so a setup run wrote into a literal `{project-root}/` directory **under the skill folder** instead of the project root:

```
.../.claude/skills/bmad-bmb-setup/{project-root}/_bmad/module-help.csv
```

This predates the current `main` — the literal token in the script invocations has been present since the skill was first scaffolded.

## Fix (two layers)

**Docs (root cause).** Scope the literal-token rule to config *values* (the data written into the files), and explicitly instruct resolving `{project-root}` to the actual project root in script path *arguments*. Applied to:
- `skills/bmad-bmb-setup/SKILL.md`
- `skills/bmad-module-builder/assets/setup-skill-template/SKILL.md`
- `skills/bmad-module-builder/assets/standalone-module-template/module-setup.md`
- both samples (`sample-module-setup`, `bmad-agent-dream-weaver`)

**Scripts (defense in depth).** Add a `reject_unresolved_paths()` guard to `merge-help-csv.py`, `merge-config.py`, and `cleanup-legacy.py` (all 13 copies). If a path argument still contains `{project-root}`, the script now exits non-zero with a clear JSON error instead of silently creating a junk directory.

## Verification

- Guard rejects an unresolved token (exit 1, no directory created).
- Happy path with a resolved path still succeeds.
- All three scripts parse cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Setup scripts now validate filesystem path arguments and fail fast (print a structured JSON error and exit) if the literal `{project-root}` token remains, preventing accidental creation of `{project-root}/...`.

* **Documentation**
  * Clarified that `{project-root}` stays literal inside config values but must be replaced with real filesystem paths in script CLI arguments; noted merge scripts can run in parallel.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->