### PR TITLE
fix(eval-runner): require trusted adapter configuration

### DIFF
--- a/skills/bmad-eval-runner/SKILL.md
+++ b/skills/bmad-eval-runner/SKILL.md
@@ -47,7 +47,7 @@ These map directly onto the script CLIs below; anything not listed there (case s
 
 4. Locate the skill and verify `<skill-path>/SKILL.md` exists. Halt with a clear error if it does not.
 
-5. Resolve the adapter config per the discovery rules in `references/platform-adapter.md` (explicit `--adapter`, `BMAD_EVAL_ADAPTER`, `adapter.json` beside the cases file). When nothing is configured and the current runtime is Claude Code, use `{skill-root}/assets/adapter-claude-code.json`.
+5. Resolve the adapter config per the trusted configuration rules in `references/platform-adapter.md` (explicit `--adapter` or `BMAD_EVAL_ADAPTER`). Never load an adapter from beside an untrusted cases or queries file. When nothing is configured and the current runtime is Claude Code, use `{skill-root}/assets/adapter-claude-code.json`.
 
 6. Discover the cases file. Look at `--evals` first, then `<skill-path>/evals/`, then `<skill-path>/../../evals/<skill-name>/`, then `<project-root>/evals/<skill-name>/`, then anywhere under `<project-root>/evals/`. Take the first match. If nothing is found, halt and say so; the runner does not invent cases.
 

--- a/skills/bmad-eval-runner/references/platform-adapter.md
+++ b/skills/bmad-eval-runner/references/platform-adapter.md
@@ -34,9 +34,13 @@ An adapter is a JSON file the scripts read. A working Claude Code adapter ships 
 
 1. `--adapter <path>` on the command line.
 2. `BMAD_EVAL_ADAPTER` env var pointing at a config file.
-3. `adapter.json` or `.bmad-eval-adapter.json` beside the cases/queries file.
 
-Nothing found means the run degrades to staging-only (cases prepared, results recorded as skipped). When the current runtime is Claude Code and no project adapter exists, pass `--adapter {skill-root}/assets/adapter-claude-code.json`.
+The runner never searches beside the cases/queries file. Those directories may
+come from an untrusted bundle, and the adapter controls executable argv and
+optional host-environment forwarding. Nothing found means the run degrades to
+staging-only (cases prepared, results recorded as skipped). When the current
+runtime is Claude Code and no project adapter exists, pass
+`--adapter {skill-root}/assets/adapter-claude-code.json`.
 
 ## Invocation and isolation
 

--- a/skills/bmad-eval-runner/scripts/adapter.py
+++ b/skills/bmad-eval-runner/scripts/adapter.py
@@ -1,0 +1,76 @@
+"""Trusted adapter configuration helpers for the eval runners.
+
+Adapter configuration is executable configuration: it chooses the subprocess
+argv and which host environment variables are forwarded. It must therefore be
+selected by an explicit command-line option or an operator-controlled
+environment variable, never by a file shipped beside an untrusted eval bundle.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Mapping
+from pathlib import Path
+
+
+def find_adapter(explicit: Path | None, _data_file: Path) -> Path | None:
+    """Return only explicitly selected adapter configuration.
+
+    ``data_file`` is accepted to keep the call contract clear at both runner
+    sites, but its parent directory is deliberately never searched. Cases and
+    query bundles are untrusted input and may contain an adjacent adapter that
+    would otherwise control command execution.
+    """
+    if explicit is not None:
+        return explicit if explicit.is_file() else None
+
+    env_path = os.environ.get("BMAD_EVAL_ADAPTER")
+    if env_path:
+        candidate = Path(env_path).expanduser()
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def load_adapter(path: Path) -> dict:
+    """Load and minimally validate a trusted adapter configuration."""
+    cfg = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(cfg, dict):
+        raise ValueError(f"adapter config must be a JSON object: {path}")
+    if "invocation" not in cfg or not isinstance(cfg["invocation"], list):
+        raise ValueError("adapter config missing 'invocation' argv list")
+    return cfg
+
+
+def build_argv(invocation: list, prompt: str, cwd: str) -> list[str]:
+    """Expand the supported prompt, query, and cwd argv placeholders."""
+    argv: list[str] = []
+    for tok in invocation:
+        tok = str(tok)
+        tok = (tok.replace("{prompt}", prompt)
+               .replace("{query}", prompt)
+               .replace("{cwd}", cwd))
+        argv.append(tok)
+    return argv
+
+
+def build_case_env(adapter: Mapping | None, home_dir: Path,
+                   host_env: Mapping[str, str]) -> dict[str, str]:
+    """Build the minimal subprocess environment from trusted config."""
+    adapter = adapter or {}
+    env = {
+        "PATH": host_env.get("PATH", ""),
+        "HOME": str(home_dir),
+        "CLAUDE_CONFIG_DIR": str(home_dir / ".claude"),
+    }
+    auth_env = adapter.get("auth_env")
+    if auth_env:
+        val = host_env.get(str(auth_env))
+        if val:
+            env[str(auth_env)] = val
+    for key in adapter.get("env_passthrough") or []:
+        val = host_env.get(str(key))
+        if val is not None:
+            env[str(key)] = val
+    return env

--- a/skills/bmad-eval-runner/scripts/adapter.py
+++ b/skills/bmad-eval-runner/scripts/adapter.py
@@ -23,7 +23,8 @@ def find_adapter(explicit: Path | None, _data_file: Path) -> Path | None:
     would otherwise control command execution.
     """
     if explicit is not None:
-        return explicit if explicit.is_file() else None
+        candidate = explicit.expanduser()
+        return candidate if candidate.is_file() else None
 
     env_path = os.environ.get("BMAD_EVAL_ADAPTER")
     if env_path:
@@ -38,7 +39,9 @@ def load_adapter(path: Path) -> dict:
     cfg = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(cfg, dict):
         raise ValueError(f"adapter config must be a JSON object: {path}")
-    if "invocation" not in cfg or not isinstance(cfg["invocation"], list):
+    if ("invocation" not in cfg
+            or not isinstance(cfg["invocation"], list)
+            or not cfg["invocation"]):
         raise ValueError("adapter config missing 'invocation' argv list")
     return cfg
 

--- a/skills/bmad-eval-runner/scripts/run_evals.py
+++ b/skills/bmad-eval-runner/scripts/run_evals.py
@@ -90,10 +90,11 @@ import shutil
 import subprocess
 import sys
 import time
-from collections.abc import Mapping
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
 from pathlib import Path
+
+from adapter import build_argv, build_case_env, find_adapter, load_adapter
 
 
 # --- small self-contained helpers (no Docker/keychain imports) -------------
@@ -113,73 +114,6 @@ def write_json(path: Path, data: object) -> None:
 
 def read_json(path: Path) -> object:
     return json.loads(path.read_text(encoding="utf-8"))
-
-
-# --- adapter ----------------------------------------------------------------
-
-def find_adapter(explicit: Path | None, cases_file: Path) -> Path | None:
-    """Locate the adapter config. Returns None when none is configured."""
-    if explicit is not None:
-        return explicit if explicit.is_file() else None
-    env_path = os.environ.get("BMAD_EVAL_ADAPTER")
-    if env_path and Path(env_path).is_file():
-        return Path(env_path)
-    for candidate in (
-        cases_file.parent / "adapter.json",
-        cases_file.parent / ".bmad-eval-adapter.json",
-    ):
-        if candidate.is_file():
-            return candidate
-    return None
-
-
-def load_adapter(path: Path) -> dict:
-    cfg = read_json(path)
-    if not isinstance(cfg, dict):
-        raise ValueError(f"adapter config must be a JSON object: {path}")
-    if "invocation" not in cfg or not isinstance(cfg["invocation"], list):
-        raise ValueError("adapter config missing 'invocation' argv list")
-    return cfg
-
-
-def build_argv(invocation: list, prompt: str, cwd: str) -> list[str]:
-    argv: list[str] = []
-    for tok in invocation:
-        tok = str(tok)
-        tok = (tok.replace("{prompt}", prompt)
-               .replace("{query}", prompt)
-               .replace("{cwd}", cwd))
-        argv.append(tok)
-    return argv
-
-
-def build_case_env(adapter: Mapping | None, home_dir: Path,
-                   host_env: Mapping[str, str]) -> dict[str, str]:
-    """Build the subprocess environment from scratch — never from os.environ.
-
-    Inheriting the host env would leak shell config, tokens, and runtime
-    state into the clean room. The env holds exactly: PATH, a fresh HOME,
-    CLAUDE_CONFIG_DIR inside it, the adapter's auth var ONLY when set
-    non-empty in the host (an empty-string auth var breaks the runtime's own
-    credential fallback), and any adapter env_passthrough keys present in
-    the host env.
-    """
-    adapter = adapter or {}
-    env = {
-        "PATH": host_env.get("PATH", ""),
-        "HOME": str(home_dir),
-        "CLAUDE_CONFIG_DIR": str(home_dir / ".claude"),
-    }
-    auth_env = adapter.get("auth_env")
-    if auth_env:
-        val = host_env.get(str(auth_env))
-        if val:
-            env[str(auth_env)] = val
-    for key in adapter.get("env_passthrough") or []:
-        val = host_env.get(str(key))
-        if val is not None:
-            env[str(key)] = val
-    return env
 
 
 # --- staging: skill under test + fixtures ------------------------------------
@@ -470,8 +404,8 @@ def main(argv: list[str] | None = None) -> int:
                    help="base for resolving fixture paths; defaults to the "
                         "cases file's directory")
     p.add_argument("--adapter", type=Path, default=None,
-                   help="adapter config JSON; defaults to BMAD_EVAL_ADAPTER env "
-                        "or adapter.json beside the cases file")
+                   help="trusted adapter config JSON; defaults to the "
+                        "BMAD_EVAL_ADAPTER environment variable")
     p.add_argument("--case-ids", default=None,
                    help="comma-separated subset of case ids to run")
     p.add_argument("--runs", type=int, default=1,

--- a/skills/bmad-eval-runner/scripts/run_evals.py
+++ b/skills/bmad-eval-runner/scripts/run_evals.py
@@ -94,7 +94,8 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
 from pathlib import Path
 
-from adapter import build_argv, build_case_env, find_adapter, load_adapter
+import adapter
+from adapter import build_argv, build_case_env, load_adapter
 
 
 # --- small self-contained helpers (no Docker/keychain imports) -------------
@@ -114,6 +115,11 @@ def write_json(path: Path, data: object) -> None:
 
 def read_json(path: Path) -> object:
     return json.loads(path.read_text(encoding="utf-8"))
+
+
+def find_adapter(explicit: Path | None, cases_file: Path) -> Path | None:
+    """Resolve adapter configuration through this runner's public seam."""
+    return adapter.find_adapter(explicit, cases_file)
 
 
 # --- staging: skill under test + fixtures ------------------------------------

--- a/skills/bmad-eval-runner/scripts/run_triggers.py
+++ b/skills/bmad-eval-runner/scripts/run_triggers.py
@@ -65,7 +65,8 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
 from pathlib import Path
 
-from adapter import build_argv, build_case_env, find_adapter, load_adapter
+import adapter
+from adapter import build_argv, build_case_env, load_adapter
 
 
 # --- self-contained helpers -------------------------------------------------
@@ -85,6 +86,11 @@ def write_json(path: Path, data: object) -> None:
 
 def read_json(path: Path) -> object:
     return json.loads(path.read_text(encoding="utf-8"))
+
+
+def find_adapter(explicit: Path | None, queries_file: Path) -> Path | None:
+    """Resolve adapter configuration through this runner's public seam."""
+    return adapter.find_adapter(explicit, queries_file)
 
 
 def parse_skill_md(skill_path: Path) -> tuple[str, str]:

--- a/skills/bmad-eval-runner/scripts/run_triggers.py
+++ b/skills/bmad-eval-runner/scripts/run_triggers.py
@@ -65,6 +65,8 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
 from pathlib import Path
 
+from adapter import build_argv, build_case_env, find_adapter, load_adapter
+
 
 # --- self-contained helpers -------------------------------------------------
 
@@ -113,69 +115,6 @@ def parse_skill_md(skill_path: Path) -> tuple[str, str]:
     if not name:
         raise ValueError(f"SKILL.md at {skill_path} has no name")
     return name, " ".join(desc_lines).strip()
-
-
-# --- adapter ----------------------------------------------------------------
-
-def find_adapter(explicit: Path | None, queries_file: Path) -> Path | None:
-    if explicit is not None:
-        return explicit if explicit.is_file() else None
-    env_path = os.environ.get("BMAD_EVAL_ADAPTER")
-    if env_path and Path(env_path).is_file():
-        return Path(env_path)
-    for candidate in (
-        queries_file.parent / "adapter.json",
-        queries_file.parent / ".bmad-eval-adapter.json",
-    ):
-        if candidate.is_file():
-            return candidate
-    return None
-
-
-def load_adapter(path: Path) -> dict:
-    cfg = read_json(path)
-    if not isinstance(cfg, dict) or "invocation" not in cfg:
-        raise ValueError(f"adapter config missing 'invocation': {path}")
-    return cfg
-
-
-def build_argv(invocation: list, query: str, cwd: str) -> list[str]:
-    out: list[str] = []
-    for tok in invocation:
-        tok = (str(tok).replace("{prompt}", query)
-               .replace("{query}", query)
-               .replace("{cwd}", cwd))
-        out.append(tok)
-    return out
-
-
-def build_case_env(adapter: dict | None, home_dir: Path,
-                   host_env: dict) -> dict[str, str]:
-    """Build the subprocess environment from scratch — never from os.environ.
-
-    Inheriting the host env would leak shell config, tokens, and runtime
-    state into the clean room. The env holds exactly: PATH, a fresh HOME,
-    CLAUDE_CONFIG_DIR inside it, the adapter's auth var ONLY when set
-    non-empty in the host (an empty-string auth var breaks the runtime's own
-    credential fallback), and any adapter env_passthrough keys present in
-    the host env.
-    """
-    adapter = adapter or {}
-    env = {
-        "PATH": host_env.get("PATH", ""),
-        "HOME": str(home_dir),
-        "CLAUDE_CONFIG_DIR": str(home_dir / ".claude"),
-    }
-    auth_env = adapter.get("auth_env")
-    if auth_env:
-        val = host_env.get(str(auth_env))
-        if val:
-            env[str(auth_env)] = val
-    for key in adapter.get("env_passthrough") or []:
-        val = host_env.get(str(key))
-        if val is not None:
-            env[str(key)] = val
-    return env
 
 
 # --- synthetic skill staging ------------------------------------------------
@@ -309,7 +248,9 @@ def main(argv: list[str] | None = None) -> int:
     p.add_argument("--skill-path", required=True, type=Path)
     p.add_argument("--queries", required=True, type=Path)
     p.add_argument("--output-dir", required=True, type=Path)
-    p.add_argument("--adapter", type=Path, default=None)
+    p.add_argument("--adapter", type=Path, default=None,
+                   help="trusted adapter config JSON; defaults to the "
+                        "BMAD_EVAL_ADAPTER environment variable")
     p.add_argument("--runs-per-query", type=int, default=3)
     p.add_argument("--threshold", type=float, default=0.5)
     p.add_argument("--timeout", type=int, default=60)

--- a/skills/bmad-eval-runner/scripts/tests/test_adapter_resolution.py
+++ b/skills/bmad-eval-runner/scripts/tests/test_adapter_resolution.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Guard the adapter trust boundary in both eval runners."""
+
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import run_evals  # noqa: E402
+import run_triggers  # noqa: E402
+
+FINDERS = [run_evals.find_adapter, run_triggers.find_adapter]
+
+
+def write_adapter(path: Path) -> None:
+    path.write_text(json.dumps({"invocation": ["trusted-runtime"]}),
+                    encoding="utf-8")
+
+
+def test_sibling_adapter_is_ignored():
+    with tempfile.TemporaryDirectory() as temp:
+        root = Path(temp)
+        data_file = root / "cases.json"
+        sibling = root / "adapter.json"
+        data_file.write_text("[]", encoding="utf-8")
+        write_adapter(sibling)
+        with patch.dict(os.environ, {}, clear=True):
+            for find in FINDERS:
+                assert find(None, data_file) is None, find.__module__
+
+
+def test_explicit_adapter_is_used_even_beside_bundle():
+    with tempfile.TemporaryDirectory() as temp:
+        root = Path(temp)
+        data_file = root / "queries.json"
+        explicit = root / "trusted" / "adapter.json"
+        data_file.write_text("[]", encoding="utf-8")
+        (root / "trusted").mkdir()
+        write_adapter(explicit)
+        (root / "adapter.json").write_text(
+            json.dumps({"invocation": ["attacker-controlled"]}),
+            encoding="utf-8",
+        )
+        with patch.dict(os.environ, {}, clear=True):
+            for find in FINDERS:
+                assert find(explicit, data_file) == explicit
+
+
+def test_operator_environment_adapter_is_used():
+    with tempfile.TemporaryDirectory() as temp:
+        root = Path(temp)
+        data_file = root / "cases.json"
+        configured = root / "trusted-adapter.json"
+        data_file.write_text("[]", encoding="utf-8")
+        write_adapter(configured)
+        with patch.dict(os.environ,
+                        {"BMAD_EVAL_ADAPTER": str(configured)}, clear=True):
+            for find in FINDERS:
+                assert find(None, data_file) == configured
+
+
+if __name__ == "__main__":
+    test_sibling_adapter_is_ignored()
+    test_explicit_adapter_is_used_even_beside_bundle()
+    test_operator_environment_adapter_is_used()
+    print("ok: adapter selection requires explicit trusted configuration")

--- a/skills/bmad-eval-runner/scripts/tests/test_adapter_resolution.py
+++ b/skills/bmad-eval-runner/scripts/tests/test_adapter_resolution.py
@@ -14,7 +14,10 @@ sys.path.insert(0, str(SCRIPTS_DIR))
 import run_evals  # noqa: E402
 import run_triggers  # noqa: E402
 
-FINDERS = [run_evals.find_adapter, run_triggers.find_adapter]
+FINDERS = [
+    ("run_evals", run_evals.find_adapter),
+    ("run_triggers", run_triggers.find_adapter),
+]
 
 
 def write_adapter(path: Path) -> None:
@@ -26,12 +29,12 @@ def test_sibling_adapter_is_ignored():
     with tempfile.TemporaryDirectory() as temp:
         root = Path(temp)
         data_file = root / "cases.json"
-        sibling = root / "adapter.json"
         data_file.write_text("[]", encoding="utf-8")
-        write_adapter(sibling)
+        for filename in ("adapter.json", ".bmad-eval-adapter.json"):
+            write_adapter(root / filename)
         with patch.dict(os.environ, {}, clear=True):
-            for find in FINDERS:
-                assert find(None, data_file) is None, find.__module__
+            for runner, find in FINDERS:
+                assert find(None, data_file) is None, runner
 
 
 def test_explicit_adapter_is_used_even_beside_bundle():
@@ -39,16 +42,20 @@ def test_explicit_adapter_is_used_even_beside_bundle():
         root = Path(temp)
         data_file = root / "queries.json"
         explicit = root / "trusted" / "adapter.json"
+        configured = root / "trusted" / "env-adapter.json"
         data_file.write_text("[]", encoding="utf-8")
         (root / "trusted").mkdir()
         write_adapter(explicit)
-        (root / "adapter.json").write_text(
-            json.dumps({"invocation": ["attacker-controlled"]}),
-            encoding="utf-8",
-        )
-        with patch.dict(os.environ, {}, clear=True):
-            for find in FINDERS:
-                assert find(explicit, data_file) == explicit
+        write_adapter(configured)
+        for filename in ("adapter.json", ".bmad-eval-adapter.json"):
+            (root / filename).write_text(
+                json.dumps({"invocation": ["attacker-controlled"]}),
+                encoding="utf-8",
+            )
+        with patch.dict(os.environ,
+                        {"BMAD_EVAL_ADAPTER": str(configured)}, clear=True):
+            for runner, find in FINDERS:
+                assert find(explicit, data_file) == explicit, runner
 
 
 def test_operator_environment_adapter_is_used():
@@ -60,12 +67,27 @@ def test_operator_environment_adapter_is_used():
         write_adapter(configured)
         with patch.dict(os.environ,
                         {"BMAD_EVAL_ADAPTER": str(configured)}, clear=True):
-            for find in FINDERS:
-                assert find(None, data_file) == configured
+            for runner, find in FINDERS:
+                assert find(None, data_file) == configured, runner
+
+
+def test_empty_invocation_is_rejected():
+    with tempfile.TemporaryDirectory() as temp:
+        config = Path(temp) / "empty.json"
+        config.write_text(json.dumps({"invocation": []}), encoding="utf-8")
+        for runner in (run_evals, run_triggers):
+            try:
+                runner.load_adapter(config)
+            except ValueError as exc:
+                assert "invocation" in str(exc), runner.__name__
+            else:
+                raise AssertionError(
+                    f"{runner.__name__} accepted an empty invocation")
 
 
 if __name__ == "__main__":
     test_sibling_adapter_is_ignored()
     test_explicit_adapter_is_used_even_beside_bundle()
     test_operator_environment_adapter_is_used()
+    test_empty_invocation_is_rejected()
     print("ok: adapter selection requires explicit trusted configuration")


### PR DESCRIPTION
## What
Remove implicit adapter discovery from untrusted evaluation bundles.

## Why
`adapter.json` beside a cases or queries file controlled the executable argv and optional host-environment forwarding passed to `subprocess.run`. A developer running a third-party bundle could therefore execute arbitrary local commands as the evaluator user. The same root cause affected both eval runners.

Fixes #103

## How
- Centralize adapter selection and execution-environment helpers.
- Accept only explicit `--adapter` or operator-controlled `BMAD_EVAL_ADAPTER` configuration.
- Ignore sibling adapter files and document the trust boundary.
- Add regression coverage for both runners.

## Testing
- `python3 -m pytest -q skills/bmad-eval-runner/scripts/tests` — 15 passed.
- Plain self-checks for all three runner test files pass.
- `git diff --check` passes.
- JS lint/format could not run because dependencies are not installed; `npm test` is not defined in this package.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved adapter selection using explicitly configured paths or the `BMAD_EVAL_ADAPTER` environment setting.
  * Prevented untrusted adapter files beside evaluation data from being used.
  * Added safer adapter validation and controlled execution environments.
  * Evaluation runs now fall back to staging-only when no adapter is configured, with an explicit Claude Code default path.

* **Tests**
  * Added coverage for adapter precedence, environment-based configuration, and ignored adjacent adapter files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->