### PR TITLE
chore: sync marketplace plugin version to 2.2.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "bmad-builder",
       "source": "./",
       "description": "Build AI agents, workflows, and modules from a conversation. Four skills — Agent Builder, Workflow Builder, Module Builder, and Setup — guide you from idea to production-ready skill structure with built-in quality optimization. Part of the BMad Method ecosystem.",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "author": {
         "name": "Brian (BMad) Madison"
       },
@@ -22,7 +22,7 @@
       "name": "sample-plugins",
       "source": "./",
       "description": "Sample plugins demonstrating how to build BMad agents and skills. Includes a code coach, creative muse, diagram reviewer, dream weaver, sentinel, and excalidraw generator.",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "author": {
         "name": "Brian (BMad) Madison"
       },
@@ -40,7 +40,7 @@
       "name": "bmad-dream-weaver-agent",
       "source": "./",
       "description": "Dream journaling and interpretation agent with lucid dreaming coaching, pattern discovery, symbol analysis, and recall training.",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "author": {
         "name": "Brian (BMad) Madison"
       },


### PR DESCRIPTION
The release workflow bumps `package.json` but does not touch `.claude-plugin/marketplace.json`, so its versions drift unless bumped by hand. Bumping ahead of the 2.2.1 patch release.