### PR TITLE
fix: exempt agent-builder operational files from scan false positives

### DIFF
--- a/skills/bmad-agent-builder/scripts/prepass.py
+++ b/skills/bmad-agent-builder/scripts/prepass.py
@@ -49,7 +49,7 @@ from pathlib import Path
 SCRIPT_DIR = Path(__file__).resolve().parent
 
 # Directories we never descend into while counting agent files.
-SKIP_DIRS = {".git", "__pycache__", ".pytest_cache", "node_modules", ".venv", "venv"}
+SKIP_DIRS = {".analysis", ".git", "__pycache__", ".pytest_cache", "node_modules", ".venv", "venv"}
 
 # Extensions we treat as countable text. Binary or opaque assets are skipped.
 TEXT_SUFFIXES = {

--- a/skills/bmad-agent-builder/scripts/scan-path-standards.py
+++ b/skills/bmad-agent-builder/scripts/scan-path-standards.py
@@ -26,7 +26,6 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
-
 # Patterns to detect
 # Double-prefix: {project-root}/{config-variable} — config vars already contain project-root
 DOUBLE_PREFIX_RE = re.compile(r'\{project-root\}/\{[^}]+\}')
@@ -121,7 +120,9 @@ def check_root_md_files(skill_path: Path) -> list[dict]:
     """Check that no .md files exist at skill root except SKILL.md."""
     findings = []
     for md_file in skill_path.glob('*.md'):
-        if md_file.name != 'SKILL.md':
+        # Agent Builder keeps its append-only process log at this exact root path
+        # for resume detection. It is operational metadata, not a prompt file.
+        if md_file.name not in {'SKILL.md', '.memlog.md'}:
             findings.append({
                 'file': md_file.name,
                 'line': 0,
@@ -229,7 +230,11 @@ def scan_skill(skill_path: Path, skip_fenced: bool = True) -> dict:
         all_findings.extend(check_frontmatter(content, skill_md))
 
     # Find all .md and .json files
-    md_files = sorted(list(skill_path.rglob('*.md')) + list(skill_path.rglob('*.json')))
+    md_files = sorted(
+        path
+        for path in list(skill_path.rglob('*.md')) + list(skill_path.rglob('*.json'))
+        if '.analysis' not in path.parts
+    )
     if not md_files:
         print(f"Warning: No .md or .json files found in {skill_path}", file=sys.stderr)
 


### PR DESCRIPTION
## What

Updated Agent Builder analysis tooling to exclude required operational metadata and generated analysis artifacts from agent-source checks.

## Why

Root `.memlog.md` is required for Agent Builder resume detection, while `.analysis/` contains generated reports. Treating either as authored agent content creates false-positive lint failures and pollutes later analysis metrics.  
Fixes #113 

## How

- Exempt root `.memlog.md` from the “only `SKILL.md` at skill root” path rule.
- Exclude `.analysis/` from path-standard scans.
- Exclude `.analysis/` from pre-pass file and token counting.

## Testing

Ran `scan-path-standards.py` against an agent containing both `.memlog.md` and generated `.analysis/` reports; it completed with no false positives. Ran `prepass.py` and verified generated analysis artifacts were absent from its file inventory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated skill validation to recognize `.memlog.md` files as valid Markdown.
  * Excluded `.analysis` directories from file scanning and token-counting checks.
  * Improved scan accuracy by preventing internal analysis artifacts from affecting validation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->